### PR TITLE
Add reinforcement learning trainer for Geometry Dash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+models/
+profiles/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # Geometrydash-AI
+
+Dieses Projekt implementiert eine vereinfachte Reinforcement-Learning-Umgebung, die sich am Spiel *Geometry Dash* orientiert. Ein Deep-Q-Network-Agent wird trainiert, um Hindernissen auszuweichen und ein Level zu vervollständigen. Für jedes Level wird automatisch ein eigenes Profil angelegt, in dem Fortschritte gespeichert werden. Während des Trainings erscheinen zwei Fenster: Eines zeigt den aktuellen Zustand des Levels und die Aktionen des Agenten, ein weiteres visualisiert den Trainingsfortschritt als Graph.
+
+## Features
+
+- **Level-Profile**: Persistente Profile pro Level, die automatisch erstellt und aktualisiert werden.
+- **Neurales Netz**: Ein DQN-Agent mit Erfahrungsspeicher und Target-Netzwerk.
+- **Reward-System**: Belohnungen basieren auf Fortschritt, Kollisionsvermeidung und erfolgreichen Abschlüssen.
+- **Visualisierung**: Zwei Matplotlib-Fenster zeigen die Spielszene sowie Verlauf von Belohnungen und Verlusten.
+
+## Voraussetzungen
+
+Installiere die Abhängigkeiten (idealerweise in einer virtuellen Umgebung):
+
+```bash
+pip install -r requirements.txt
+```
+
+## Training starten
+
+Starte das Training mit:
+
+```bash
+python main.py --episodes 200
+```
+
+Optionen:
+
+- `--level`: Name des Levels (Standard: `training_ground`).
+- `--episodes`: Anzahl der Trainings-Episoden.
+- `--no-visualization`: Deaktiviert die Matplotlib-Fenster.
+- `--model-dir`: Ordner für gespeicherte Modelle.
+- `--profiles-dir`: Ordner für Level-Profile.
+- `--device`: Torch-Device (`cpu` oder `cuda`).
+
+Beim Training werden Modelle regelmäßig im angegebenen Model-Ordner abgelegt und Level-Profile im Profil-Ordner gespeichert.

--- a/geometrydash_ai/__init__.py
+++ b/geometrydash_ai/__init__.py
@@ -1,0 +1,17 @@
+"""Geometry Dash inspired reinforcement learning package."""
+
+from .agent import AgentConfig, DQNAgent
+from .environment import DEFAULT_TRANSFORMATIONS, GeometryDashEnv, demo_level
+from .profile_manager import ProfileManager
+from .trainer import Trainer, TrainingConfig
+
+__all__ = [
+    "AgentConfig",
+    "DQNAgent",
+    "DEFAULT_TRANSFORMATIONS",
+    "GeometryDashEnv",
+    "demo_level",
+    "ProfileManager",
+    "Trainer",
+    "TrainingConfig",
+]

--- a/geometrydash_ai/agent.py
+++ b/geometrydash_ai/agent.py
@@ -1,0 +1,110 @@
+"""Deep Q-Network agent for the Geometry Dash environment."""
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+import random
+from typing import Deque, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.optim as optim
+
+
+class QNetwork(nn.Module):
+    """Simple feed-forward network."""
+
+    def __init__(self, input_dim: int, output_dim: int, hidden_dim: int = 128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, output_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+@dataclass
+class AgentConfig:
+    gamma: float = 0.99
+    epsilon_start: float = 1.0
+    epsilon_end: float = 0.05
+    epsilon_decay: int = 500
+    buffer_size: int = 50_000
+    batch_size: int = 64
+    learning_rate: float = 1e-3
+    target_update_interval: int = 200
+    device: str = "cpu"
+
+
+class DQNAgent:
+    """Implements a DQN agent with experience replay."""
+
+    def __init__(self, state_dim: int, action_dim: int, config: AgentConfig | None = None):
+        self.config = config or AgentConfig()
+        self.device = torch.device(self.config.device)
+        self.policy_net = QNetwork(state_dim, action_dim).to(self.device)
+        self.target_net = QNetwork(state_dim, action_dim).to(self.device)
+        self.target_net.load_state_dict(self.policy_net.state_dict())
+        self.optimizer = optim.Adam(self.policy_net.parameters(), lr=self.config.learning_rate)
+        self.memory: Deque[Tuple[np.ndarray, int, float, np.ndarray, bool]] = deque(maxlen=self.config.buffer_size)
+        self.steps_done = 0
+        self.action_dim = action_dim
+
+    def select_action(self, state: np.ndarray) -> int:
+        epsilon = self._epsilon_by_frame(self.steps_done)
+        self.steps_done += 1
+        if random.random() < epsilon:
+            return random.randrange(self.action_dim)
+        state_t = torch.tensor(state, dtype=torch.float32, device=self.device).unsqueeze(0)
+        with torch.no_grad():
+            action_values = self.policy_net(state_t)
+        return int(action_values.argmax().item())
+
+    def store_transition(self, state, action, reward, next_state, done) -> None:
+        self.memory.append((state, action, reward, next_state, done))
+
+    def update(self) -> float:
+        if len(self.memory) < self.config.batch_size:
+            return 0.0
+        batch = random.sample(self.memory, self.config.batch_size)
+        states, actions, rewards, next_states, dones = zip(*batch)
+
+        states_t = torch.tensor(np.array(states), dtype=torch.float32, device=self.device)
+        actions_t = torch.tensor(actions, dtype=torch.int64, device=self.device).unsqueeze(-1)
+        rewards_t = torch.tensor(rewards, dtype=torch.float32, device=self.device)
+        next_states_t = torch.tensor(np.array(next_states), dtype=torch.float32, device=self.device)
+        dones_t = torch.tensor(dones, dtype=torch.float32, device=self.device)
+
+        current_q = self.policy_net(states_t).gather(1, actions_t).squeeze()
+        with torch.no_grad():
+            max_next_q = self.target_net(next_states_t).max(1)[0]
+            target_q = rewards_t + (1 - dones_t) * self.config.gamma * max_next_q
+
+        loss = nn.functional.mse_loss(current_q, target_q)
+        self.optimizer.zero_grad()
+        loss.backward()
+        self.optimizer.step()
+
+        if self.steps_done % self.config.target_update_interval == 0:
+            self.target_net.load_state_dict(self.policy_net.state_dict())
+
+        return float(loss.item())
+
+    def save(self, path: str) -> None:
+        torch.save(self.policy_net.state_dict(), path)
+
+    def load(self, path: str) -> None:
+        state_dict = torch.load(path, map_location=self.device)
+        self.policy_net.load_state_dict(state_dict)
+        self.target_net.load_state_dict(self.policy_net.state_dict())
+
+    def _epsilon_by_frame(self, frame_idx: int) -> float:
+        epsilon = self.config.epsilon_end + (self.config.epsilon_start - self.config.epsilon_end) * \
+            np.exp(-1.0 * frame_idx / self.config.epsilon_decay)
+        return float(epsilon)

--- a/geometrydash_ai/environment.py
+++ b/geometrydash_ai/environment.py
@@ -1,0 +1,181 @@
+"""Simplified Geometry Dash-like environment for reinforcement learning."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass
+class Transformation:
+    """Represents a transformation (form) the player can take."""
+
+    name: str
+    gravity: float
+    jump_strength: float
+    terminal_velocity: float
+
+
+@dataclass
+class Obstacle:
+    """Represents a simple obstacle within the level."""
+
+    position: float
+    height: float
+    width: float
+
+    def collides(self, player_pos: float, player_height: float) -> bool:
+        within_horizontal = self.position <= player_pos <= self.position + self.width
+        if not within_horizontal:
+            return False
+        return player_height <= self.height
+
+
+@dataclass
+class Level:
+    """Data structure describing a level layout."""
+
+    name: str
+    length: float
+    obstacles: List[Obstacle]
+    checkpoints: Optional[List[float]] = None
+
+
+@dataclass
+class LevelProfile:
+    """Stores persistent information about a level."""
+
+    name: str
+    best_distance: float = 0.0
+    completed_runs: int = 0
+    total_reward: float = 0.0
+    episodes: int = 0
+
+    def update(self, distance: float, reward: float, completed: bool) -> None:
+        self.episodes += 1
+        self.total_reward += reward
+        if completed:
+            self.completed_runs += 1
+            self.best_distance = self.length
+        else:
+            self.best_distance = max(self.best_distance, distance)
+
+    @property
+    def length(self) -> float:
+        """Proxy property to keep compatibility with the level length."""
+        return getattr(self, "_level_length", self.best_distance)
+
+    def set_level_length(self, length: float) -> None:
+        self._level_length = length
+
+
+class GeometryDashEnv:
+    """A simplified continuous 1D Geometry Dash environment."""
+
+    ACTIONS: Dict[int, str] = {0: "stay", 1: "jump", 2: "dash"}
+
+    def __init__(self, level: Level, transformations: List[Transformation]):
+        self.level = level
+        self.transformations = transformations
+        self.current_transformation = transformations[0]
+        self.player_position = 0.0
+        self.player_height = 0.0
+        self.vertical_velocity = 0.0
+        self.time_step = 0.05
+        self.speed = 5.0
+        self.gravity_multiplier = 1.0
+        self.max_time = level.length / self.speed * 1.5
+        self.elapsed_time = 0.0
+
+    def reset(self, transformation_index: int = 0) -> np.ndarray:
+        self.current_transformation = self.transformations[transformation_index]
+        self.player_position = 0.0
+        self.player_height = 0.0
+        self.vertical_velocity = 0.0
+        self.elapsed_time = 0.0
+        return self._get_observation()
+
+    def _get_observation(self) -> np.ndarray:
+        next_obstacles = sorted(
+            [ob for ob in self.level.obstacles if ob.position >= self.player_position],
+            key=lambda ob: ob.position,
+        )[:3]
+        obs = [
+            self.player_position / self.level.length,
+            self.player_height,
+            self.vertical_velocity,
+            self.transformations.index(self.current_transformation) / max(1, len(self.transformations) - 1),
+        ]
+        for obstacle in next_obstacles:
+            obs.extend([
+                (obstacle.position - self.player_position) / self.level.length,
+                obstacle.height,
+                obstacle.width,
+            ])
+        while len(obs) < 4 + 3 * 3:
+            obs.append(0.0)
+        return np.array(obs, dtype=np.float32)
+
+    def step(self, action: int) -> Tuple[np.ndarray, float, bool, Dict[str, float]]:
+        self.elapsed_time += self.time_step
+        reward = 0.0
+
+        if action == 1:  # jump
+            self.vertical_velocity = self.current_transformation.jump_strength
+        elif action == 2:  # dash, increase forward speed temporarily
+            reward -= 0.01  # discourage spam
+            self.player_position += self.speed * self.time_step * 0.5
+
+        self.vertical_velocity -= self.current_transformation.gravity * self.gravity_multiplier * self.time_step
+        self.vertical_velocity = max(-self.current_transformation.terminal_velocity, self.vertical_velocity)
+        self.player_height = max(0.0, self.player_height + self.vertical_velocity * self.time_step)
+
+        self.player_position += self.speed * self.time_step
+        distance_reward = self.speed * self.time_step / self.level.length
+        reward += distance_reward
+
+        for obstacle in self.level.obstacles:
+            if obstacle.collides(self.player_position, self.player_height):
+                reward -= 1.0
+                obs = self._get_observation()
+                return obs, reward, True, {"event": "collision", "position": self.player_position}
+
+        completed = self.player_position >= self.level.length
+        if completed:
+            reward += 1.0
+
+        timed_out = self.elapsed_time >= self.max_time
+        done = completed or timed_out
+        obs = self._get_observation()
+        info = {"event": "completed" if completed else "timeout" if timed_out else "running"}
+        return obs, reward, done, info
+
+    def sample_level_state(self) -> Dict[str, float]:
+        """Returns a snapshot of the current state for visualization."""
+        return {
+            "player_position": self.player_position,
+            "player_height": self.player_height,
+            "level_length": self.level.length,
+            "obstacles": [(ob.position, ob.height, ob.width) for ob in self.level.obstacles],
+            "transformation": self.current_transformation.name,
+        }
+
+
+DEFAULT_TRANSFORMATIONS = [
+    Transformation(name="cube", gravity=9.8, jump_strength=8.5, terminal_velocity=15.0),
+    Transformation(name="ship", gravity=6.0, jump_strength=10.0, terminal_velocity=12.0),
+]
+
+
+def demo_level(name: str = "training_ground") -> Level:
+    """Creates a deterministic demo level for experimentation."""
+    obstacles = [
+        Obstacle(position=5.0, height=0.5, width=0.5),
+        Obstacle(position=10.0, height=0.6, width=0.5),
+        Obstacle(position=12.0, height=0.4, width=0.5),
+        Obstacle(position=15.0, height=0.7, width=0.5),
+        Obstacle(position=18.0, height=0.5, width=0.5),
+        Obstacle(position=20.0, height=0.3, width=0.5),
+    ]
+    return Level(name=name, length=25.0, obstacles=obstacles)

--- a/geometrydash_ai/profile_manager.py
+++ b/geometrydash_ai/profile_manager.py
@@ -1,0 +1,44 @@
+"""Profile management for Geometry Dash levels."""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Dict
+
+from .environment import Level, LevelProfile
+
+
+@dataclass
+class ProfileConfig:
+    base_dir: Path
+
+
+class ProfileManager:
+    """Handles persistent profile storage per level."""
+
+    def __init__(self, base_dir: str | Path = "profiles"):
+        self.config = ProfileConfig(base_dir=Path(base_dir))
+        self.config.base_dir.mkdir(parents=True, exist_ok=True)
+        self.cache: Dict[str, LevelProfile] = {}
+
+    def load_or_create(self, level: Level) -> LevelProfile:
+        profile_path = self._profile_path(level.name)
+        if profile_path.exists():
+            with profile_path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            profile = LevelProfile(**data)
+        else:
+            profile = LevelProfile(name=level.name)
+        profile.set_level_length(level.length)
+        self.cache[level.name] = profile
+        return profile
+
+    def save(self, profile: LevelProfile) -> None:
+        profile_path = self._profile_path(profile.name)
+        with profile_path.open("w", encoding="utf-8") as fh:
+            json.dump(asdict(profile), fh, indent=2)
+
+    def _profile_path(self, level_name: str) -> Path:
+        safe_name = level_name.replace(" ", "_")
+        return self.config.base_dir / f"{safe_name}.json"

--- a/geometrydash_ai/trainer.py
+++ b/geometrydash_ai/trainer.py
@@ -1,0 +1,88 @@
+"""Training loop orchestration for the Geometry Dash agent."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+from .agent import DQNAgent
+from .environment import GeometryDashEnv, Level, LevelProfile
+from .profile_manager import ProfileManager
+from .visualization import TrainingVisualizer
+
+
+@dataclass
+class TrainingConfig:
+    episodes: int = 500
+    max_steps_per_episode: int = 1_000
+    save_interval: int = 50
+    model_dir: Path = Path("models")
+    visualization: bool = True
+
+
+class Trainer:
+    """Coordinates the training of the DQN agent."""
+
+    def __init__(
+        self,
+        env: GeometryDashEnv,
+        agent: DQNAgent,
+        level: Level,
+        profile_manager: Optional[ProfileManager] = None,
+        config: TrainingConfig | None = None,
+    ):
+        self.env = env
+        self.agent = agent
+        self.level = level
+        self.config = config or TrainingConfig()
+        self.profile_manager = profile_manager or ProfileManager()
+        self.profile = self.profile_manager.load_or_create(level)
+        self.config.model_dir.mkdir(parents=True, exist_ok=True)
+        self.visualizer = TrainingVisualizer(self.config.visualization)
+        self.rewards: List[float] = []
+        self.losses: List[float] = []
+        self.completions: List[bool] = []
+
+    def train(self) -> None:
+        for episode in range(1, self.config.episodes + 1):
+            state = self.env.reset()
+            total_reward = 0.0
+            completed = False
+
+            for step in range(self.config.max_steps_per_episode):
+                action = self.agent.select_action(state)
+                next_state, reward, done, info = self.env.step(action)
+                self.agent.store_transition(state, action, reward, next_state, done)
+                loss = self.agent.update()
+
+                state = next_state
+                total_reward += reward
+                if loss:
+                    self.losses.append(loss)
+                if done:
+                    completed = info.get("event") == "completed"
+                    break
+
+            self.rewards.append(total_reward)
+            self.completions.append(completed)
+            self.profile.update(self.env.player_position, total_reward, completed)
+            self.profile_manager.save(self.profile)
+
+            if episode % self.config.save_interval == 0:
+                self._save_agent(episode)
+
+            if self.visualizer.enabled:
+                level_state = self.env.sample_level_state()
+                self.visualizer.update(level_state, self.rewards, self.losses)
+
+            print(
+                f"Episode {episode:04d} | reward={total_reward:.3f} "
+                f"| completed={completed} | best_distance={self.profile.best_distance:.2f}"
+            )
+
+        self._save_agent(self.config.episodes)
+        self.visualizer.close()
+
+    def _save_agent(self, episode: int) -> None:
+        model_path = self.config.model_dir / f"{self.level.name}_episode_{episode}.pt"
+        self.agent.save(str(model_path))

--- a/geometrydash_ai/visualization.py
+++ b/geometrydash_ai/visualization.py
@@ -1,0 +1,93 @@
+"""Real-time visualization utilities for training."""
+from __future__ import annotations
+
+import itertools
+from typing import Iterable, List
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+class TrainingVisualizer:
+    """Maintains two matplotlib windows: state and training progress."""
+
+    def __init__(self, enabled: bool = True):
+        self.enabled = enabled
+        if not enabled:
+            self.state_fig = None
+            self.progress_fig = None
+            return
+
+        plt.ion()
+        self.state_fig, self.state_ax = plt.subplots(num="Environment State")
+        self.progress_fig, self.progress_ax = plt.subplots(num="Training Progress")
+        self.progress_ax.set_xlabel("Episode")
+        self.progress_ax.set_ylabel("Reward")
+        self.progress_ax.grid(True)
+        self.loss_ax = self.progress_ax.twinx()
+        self.loss_ax.set_ylabel("Loss", color="tab:orange")
+        self.loss_ax.tick_params(axis="y", labelcolor="tab:orange")
+        self._reward_line = None
+        self._loss_line = None
+
+    def update(self, level_state, rewards: List[float], losses: List[float]) -> None:
+        if not self.enabled:
+            return
+        self._draw_state(level_state)
+        self._draw_progress(rewards, losses)
+        plt.pause(0.001)
+
+    def _draw_state(self, level_state) -> None:
+        self.state_ax.clear()
+        self.state_ax.set_title(f"Transformation: {level_state['transformation']}")
+        self.state_ax.set_xlim(0, level_state["level_length"])
+        self.state_ax.set_ylim(-1, 2)
+        # Draw ground
+        self.state_ax.axhline(0, color="black")
+        # Draw player
+        self.state_ax.plot(
+            level_state["player_position"],
+            level_state["player_height"],
+            marker="o",
+            color="blue",
+        )
+        # Draw obstacles
+        for position, height, width in level_state["obstacles"]:
+            self.state_ax.add_patch(
+                plt.Rectangle(
+                    (position, 0),
+                    width,
+                    height,
+                    color="red",
+                    alpha=0.6,
+                )
+            )
+        self.state_ax.set_xlabel("Position")
+        self.state_ax.set_ylabel("Height")
+
+    def _draw_progress(self, rewards: List[float], losses: List[float]) -> None:
+        episodes = np.arange(1, len(rewards) + 1)
+        if self._reward_line is None:
+            (self._reward_line,) = self.progress_ax.plot(episodes, rewards, label="Reward", color="tab:blue")
+        else:
+            self._reward_line.set_data(episodes, rewards)
+        self.progress_ax.relim()
+        self.progress_ax.autoscale_view()
+
+        loss_x = np.arange(1, len(losses) + 1)
+        if self._loss_line is None:
+            (self._loss_line,) = self.loss_ax.plot(loss_x, losses, label="Loss", color="tab:orange", alpha=0.7)
+        else:
+            self._loss_line.set_data(loss_x, losses)
+        self.loss_ax.relim()
+        self.loss_ax.autoscale_view()
+
+        if not self.progress_ax.get_legend():
+            self.progress_ax.legend(loc="upper left")
+
+    def close(self) -> None:
+        if not self.enabled:
+            return
+        plt.ioff()
+        plt.close(self.state_fig)
+        plt.close(self.progress_fig)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,49 @@
+"""Entry point for training the Geometry Dash AI."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+
+from geometrydash_ai.agent import AgentConfig, DQNAgent
+from geometrydash_ai.environment import DEFAULT_TRANSFORMATIONS, GeometryDashEnv, demo_level
+from geometrydash_ai.profile_manager import ProfileManager
+from geometrydash_ai.trainer import Trainer, TrainingConfig
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a Geometry Dash inspired RL agent")
+    parser.add_argument("--episodes", type=int, default=200, help="Number of training episodes")
+    parser.add_argument("--level", type=str, default="training_ground", help="Level name")
+    parser.add_argument("--no-visualization", action="store_true", help="Disable visualization windows")
+    parser.add_argument("--model-dir", type=Path, default=Path("models"), help="Directory for saved models")
+    parser.add_argument("--profiles-dir", type=Path, default=Path("profiles"), help="Directory for level profiles")
+    parser.add_argument("--device", type=str, default="cpu", help="Torch device to use")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    level = demo_level(name=args.level)
+    env = GeometryDashEnv(level=level, transformations=DEFAULT_TRANSFORMATIONS)
+    dummy_state = env.reset()
+    agent = DQNAgent(state_dim=dummy_state.shape[0], action_dim=len(env.ACTIONS), config=AgentConfig(device=args.device))
+    profile_manager = ProfileManager(base_dir=args.profiles_dir)
+    trainer = Trainer(
+        env=env,
+        agent=agent,
+        level=level,
+        profile_manager=profile_manager,
+        config=TrainingConfig(
+            episodes=args.episodes,
+            model_dir=args.model_dir,
+            visualization=not args.no_visualization,
+        ),
+    )
+    trainer.train()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+numpy
+torch


### PR DESCRIPTION
## Summary
- add a simplified Geometry Dash-inspired reinforcement learning environment with transformations and obstacles
- implement a DQN agent, level profile manager, and trainer with live visualizations and persistence
- provide command-line entry point, documentation, requirements, and ignores for generated artifacts

## Testing
- python -m compileall geometrydash_ai main.py

------
https://chatgpt.com/codex/tasks/task_e_68df0df49fd08333b3601190b07a4200